### PR TITLE
feat(frontend): complete Sprint 1 base + auth audit

### DIFF
--- a/apps/frontend/angular.json
+++ b/apps/frontend/angular.json
@@ -32,8 +32,8 @@
                 "src/styles/variables.css",
                 "src/styles/reset.css",
                 "src/styles/typography.css",
-                "src/styles.css",
-                "src/styles/buttons.css"
+                "src/styles/buttons.css",
+                "src/styles.css"
               ]
           },
           "configurations": {

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { AuthLayoutComponent } from './layouts/auth-layout/auth-layout.component';
+import { authGuard } from './core/auth/auth.guard';
 
 export const routes: Routes = [
   {
@@ -10,6 +11,23 @@ export const routes: Routes = [
         path: '',
         loadChildren: () =>
           import('./features/auth/auth.routes').then(m => m.AUTH_ROUTES)
+      }
+    ]
+  },
+  {
+    path: 'admin',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./layouts/admin-layout/admin-layout.component').then(
+        m => m.AdminLayoutComponent
+      ),
+    children: [
+      {
+        path: 'dashboard',
+        loadComponent: () =>
+          import('./features/dashboard/dashboard.component').then(
+            m => m.DashboardComponent
+          )
       }
     ]
   },

--- a/apps/frontend/src/app/features/auth/login/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
 import { AuthService } from '../../../core/auth/auth.service';
 
 @Component({
@@ -31,7 +32,7 @@ export class LoginComponent {
     const { identificador, password } = this.form.value;
     this.auth.login(identificador!, password!).subscribe({
       next: () => this.router.navigate(['/admin/dashboard']),
-      error: (err) => {
+      error: (err: HttpErrorResponse) => {
         this.error.set(err.error?.message ?? 'Credenciales incorrectas');
         this.loading.set(false);
       }

--- a/apps/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/apps/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { AuthService } from '../../core/auth/auth.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  template: `
+    <div class="dashboard">
+      <h1 class="font-display">Dashboard</h1>
+      @if (auth.currentUser(); as user) {
+        <p>Bienvenido, {{ user.nombre }}</p>
+        <p>Rol: {{ user.rol ?? user.tipo }}</p>
+      }
+    </div>
+  `
+})
+export class DashboardComponent {
+  auth = inject(AuthService);
+}

--- a/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.css
+++ b/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.css
@@ -1,0 +1,8 @@
+.admin-layout {
+  min-height: 100vh;
+  background: var(--color-crema);
+}
+
+.admin-layout__content {
+  padding: 24px;
+}

--- a/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.html
+++ b/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.html
@@ -1,0 +1,5 @@
+<div class="admin-layout">
+  <div class="admin-layout__content">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.ts
+++ b/apps/frontend/src/app/layouts/admin-layout/admin-layout.component.ts
@@ -1,0 +1,17 @@
+import { Component, signal } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-admin-layout',
+  standalone: true,
+  imports: [RouterOutlet],
+  templateUrl: './admin-layout.component.html',
+  styleUrl: './admin-layout.component.css'
+})
+export class AdminLayoutComponent {
+  sidebarCollapsed = signal(false);
+
+  toggleSidebar(): void {
+    this.sidebarCollapsed.update((collapsed) => !collapsed);
+  }
+}

--- a/apps/frontend/src/styles/variables.css
+++ b/apps/frontend/src/styles/variables.css
@@ -1,6 +1,6 @@
 :root {
-  /* // ─── Colores base ─────────────────────────────────────────────── */
-  
+  /* ─── Colores base ─────────────────────────────────────────────── */
+
   --color-crema:        #F5F1E8;   /* fondo general */
   --color-beige:        #E8DFD1;   /* cards, secciones */
   --color-cafe-claro:   #C8A97E;   /* botones secundarios / hover */
@@ -15,18 +15,18 @@
   --color-warning:      #FFC107;   /* advertencia / stock bajo */
   --color-success:      #4CAF50;   /* éxito / disponible */
 
-  /* // ─── Tipografía ───────────────────────────────────────────────── */
+  /* ─── Tipografía ───────────────────────────────────────────────── */
   --font-display: 'Playfair Display', Georgia, serif;
   --font-ui:      'Inter', system-ui, sans-serif;
 
-  /* // ─── Layout ─────────────────────────────────────────────────── */
+  /* ─── Layout ─────────────────────────────────────────────────── */
   --sidebar-width:     240px;
   --topbar-height:     60px;
   --border-radius-sm:  6px;
   --border-radius-md:  10px;
   --border-radius-lg:  14px;
 
-  /* // ─── Sombras ──────────────────────────────────────────────── */
+  /* ─── Sombras ──────────────────────────────────────────────── */
   --shadow-card:  0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
   --shadow-modal: 0 4px 20px rgba(0,0,0,0.15);
 }


### PR DESCRIPTION
## Summary
Audited the Angular 22 frontend against the Sprint 1 (Base + Auth) checklist — standalone components, signals, `inject()`, native control flow (`@if`/`@for`), lazy-loaded feature routes, no `any`, pure CSS — and fixed the gaps:

- **`angular.json`**: fixed style load order — `buttons.css` was loading *after* `styles.css` instead of before it.
- **`styles/variables.css`**: cleaned up comments that mixed `//` inside `/* */` blocks (invalid style). All design tokens (colors, radii, shadows) already matched spec, including `--border-radius-lg: 14px`.
- **`login.component.ts`**: typed the error handler as `HttpErrorResponse` instead of implicit `any`.
- **`app.routes.ts`**: added the missing `/admin` route — `authGuard`-protected, lazy-loads `AdminLayoutComponent` with a `dashboard` child route. This section didn't exist before.
- **`AdminLayoutComponent`** (new): minimal shell — signal `sidebarCollapsed` + `toggleSidebar()`, container with `min-height:100vh` / `background: var(--color-crema)` / padded content area. No sidebar/topbar UI yet — that's a separate step.
- **`DashboardComponent`** (new): inline-template placeholder showing the logged-in user's name/role via `inject(AuthService)`, to prove the guard + session flow works end to end.

Everything else in the checklist (`index.html` fonts, `AuthService` session restore/signals, auth interceptor, guards, login form/template, `auth-layout`) was already correct and left untouched.

## Why
Sprint 1 was mostly done but had a few gaps that would've blocked Sprint 2 (Sidebar/Topbar, which depends on `/admin` routing and `AdminLayoutComponent` existing) and one real type-safety hole (`err: any` in the login error handler).

## Test plan
- [x] `ng build` succeeds
- [x] Lazy chunks generated for `login-component`, `admin-layout-component`, `dashboard-component`, `auth-routes`
- [x] Zero `*ngIf`/`*ngFor`/`NgIf`/`NgFor`/`AsyncPipe`/`any`/`.scss` in the codebase
- [ ] Manual click-through of login → dashboard in a browser (not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)